### PR TITLE
.pagy added before pagy styles

### DIFF
--- a/app/assets/stylesheets/pagy.tailwind.css
+++ b/app/assets/stylesheets/pagy.tailwind.css
@@ -1,7 +1,7 @@
 .pagy {
   @apply flex space-x-1 font-semibold text-sm text-gray-500;
 }
-.pagy-container a:not(.gap) {
+.pagy a:not(.gap) {
   @apply block rounded-lg px-3 py-1 bg-gray-200;
   &:hover {
     @apply bg-gray-300;
@@ -10,10 +10,10 @@
     @apply text-gray-300 bg-gray-100 cursor-default;
   }
 }
-.pagy-container .current {
+.pagy .current {
   @apply text-white bg-gray-400;
 }
-.pagy-container label {
+.pagy label {
   @apply inline-block whitespace-nowrap bg-gray-200 rounded-lg px-3 py-0.5;
   input {
     @apply bg-gray-100 border-none rounded-md;

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -40,9 +40,9 @@
               </li>
             <% end %>
           </ul>
-          <nav class="mt-4 pagy">
+          <div class="mt-4">
             <%== pagy_nav(@pagy) %>
-          </nav>
+          </div>
         <% else %>
           <p class="text-gray-600">No watering logs available.</p>
         <% end %>

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -40,7 +40,7 @@
               </li>
             <% end %>
           </ul>
-          <nav class="mt-4 pagy-container">
+          <nav class="mt-4 pagy">
             <%== pagy_nav(@pagy) %>
           </nav>
         <% else %>


### PR DESCRIPTION
I realized this issue while doing dropdown buttons. Background color existed even with no styles. 

At first I made pagy-container, but .pagy is probably better because it uses pagy gem internals ( I think that it is the case, because it works even without "pagy" in nav class="mt-4 pagy" )